### PR TITLE
Updates to the Examples

### DIFF
--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,5 @@
+.idea
+target
+*.iml
+log
+*.class

--- a/src/test/java/com/hashnot/etsy/ExampleOuth.java
+++ b/src/test/java/com/hashnot/etsy/ExampleOuth.java
@@ -1,5 +1,6 @@
 package com.hashnot.etsy;
 
+import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.RestProxyFactory;
 
 import java.io.IOException;
@@ -10,12 +11,22 @@ import java.util.logging.Logger;
 import com.hashnot.etsy.dto.Listing;
 import com.hashnot.etsy.dto.Response;
 
-public class Example {
-	private static final Logger LOGGER = Logger.getLogger(Example.class.getName());
+import oauth.signpost.OAuthConsumer;
+import oauth.signpost.basic.DefaultOAuthConsumer;
+
+public class ExampleOuth {
+	private static final Logger LOGGER = Logger.getLogger(ExampleOuth.class.getName());
 	private static final String API_KEY = "Replace with your etsy api key";
+	private static final String SECRET_KEY = "My Oauth Secret Key";
 	public static void main(String[] args) throws IOException {
     	
-    	Listings listings = RestProxyFactory.createProxy(Listings.class, Etsy.BASE_URL);
+    	ClientConfig config = new ClientConfig();
+    	
+    	
+    	OAuthConsumer oAuthConsumer = new DefaultOAuthConsumer(API_KEY,
+    			SECRET_KEY);
+		config.setOAuthConsumer(oAuthConsumer );
+        Listings listings = RestProxyFactory.createProxy(Listings.class, Etsy.BASE_URL, config);
         Response<Listing> response = listings.getListing(Collections.singleton(263361609L), 1, 0, null, null, API_KEY);
         
         List<Listing> rlistings = response.getResults();
@@ -23,5 +34,7 @@ public class Example {
         {
         	LOGGER.info(listing.toString());
         }
+        
+        
     }
 }


### PR DESCRIPTION
Minor fix to the Base URL passed into the proxy, it was including the
"/v2" in the path when these were already included in the path defined
in the com.hashnot.etsy interfaces.

Also filled out the example a bit to show getting the response and 
printing its contents to a logger.

Added an additional Example setting up Oauth