### PR TITLE
Account for responses that only return one object and not a list

### DIFF
--- a/src/main/java/com/hashnot/etsy/ListingInventorys.java
+++ b/src/main/java/com/hashnot/etsy/ListingInventorys.java
@@ -1,0 +1,96 @@
+package com.hashnot.etsy;
+
+import com.hashnot.etsy.dto.ListingInventory;
+import com.hashnot.etsy.dto.dict.DictionaryResponse;
+
+import javax.ws.rs.*;
+import java.io.IOException;
+
+/**
+ * @author rougeSE
+ */
+@Path("v2/listings")
+public interface ListingInventorys {
+
+	/**
+	 * Get the inventory for a listing
+	 * 
+	 * When a listing has not been edited using the 
+	 * new inventory tools, it will have no inventory
+	 * records. We generate suitable records on the
+	 * fly, but don’t write them out by default. If you 
+	 * need to get stable product_id and offering_id fields, 
+	 * pass the write_missing_inventory parameter as true 
+	 * and we’ll persist the records. 
+	 * 
+	 * @param listingId
+	 * @param writeMissingInventory
+	 * @param limit
+	 * @param offset
+	 * @param includes
+	 * @param fields
+	 * @param apiKey
+	 * @return
+	 * @throws IOException
+	 */
+    @GET
+    @Path("{listing_id}/inventory")
+    @Produces("application/json")
+    DictionaryResponse<ListingInventory> getInventory(
+            @PathParam("listing_id") int listingId,
+            
+            @QueryParam("write_missing_inventory") Boolean writeMissingInventory,
+           
+            @QueryParam("includes") Iterable<String> includes,
+            @QueryParam("fields") Iterable<String> fields,
+            @QueryParam("api_key")String apiKey
+    ) throws IOException;
+    
+    /**
+     * Update the inventory for a listing 
+     * 
+     *  price_on_property is an array of the 
+     *  property_ids of the properties which 
+     *  price depends on (if any).
+     *  quantity_on_property is an array of the 
+     *  property_ids of the properties which quantity 
+     *  depends on (if any).
+     *  sku_on_property is an array of the property_ids 
+     *  of the properties which sku depends on (if any).
+     *  The update will fail if the supplied values for 
+     *  product sku and offering quantity and price are 
+     *  incompatible with the supplied values of the 
+     *  "on_property_*" fields. When supplying a price, 
+     *  supply a float equivalent to amount divided by 
+     *  divisor as specified in the Money resource.
+     *  The products parameter should be a JSON 
+     *  array of products, even if you only send a single 
+     *  product. All field names in the JSON blob should 
+     *  be lowercase. 
+     * @param listingId
+     * @param products
+     * @param priceOnProperty
+     * @param quantityOnProperty
+     * @param skuOnProperty
+     * @param includes
+     * @param fields
+     * @param apiKey
+     * @throws IOException
+     */
+    @PUT
+    @Path("{listing_id}/inventory")
+    @Produces("application/json")
+    void updateInventory(
+            @PathParam("listing_id") int listingId,
+            
+            @QueryParam("products") Iterable<String> products,
+            @QueryParam("price_on_property") Iterable<Integer> priceOnProperty,
+            @QueryParam("quantity_on_property") Iterable<Integer> quantityOnProperty,
+            @QueryParam("sku_on_property") Iterable<Integer> skuOnProperty,
+            
+            @QueryParam("includes") Iterable<String> includes,
+            @QueryParam("fields") Iterable<String> fields,
+            @QueryParam("api_key")String apiKey
+    ) throws IOException;
+
+}

--- a/src/main/java/com/hashnot/etsy/ListingOfferings.java
+++ b/src/main/java/com/hashnot/etsy/ListingOfferings.java
@@ -1,0 +1,30 @@
+package com.hashnot.etsy;
+
+import com.hashnot.etsy.dto.Listing;
+import com.hashnot.etsy.dto.dict.DictionaryResponse;
+
+import javax.ws.rs.*;
+import java.io.IOException;
+
+/**
+ * @author rougeSE
+ */
+@Path("v2/listings")
+public interface ListingOfferings {
+
+    @GET
+    @Path("{listing_id}/products/{product_id}/offerings/{offering_id}")
+    @Produces("application/json")
+    DictionaryResponse<Listing> getOffering(
+            @PathParam("listing_id") int listingId,
+            @PathParam("product_id") int productId,
+            @PathParam("offering_id") int offeringId,
+
+            @QueryParam("limit") Integer limit,
+            @QueryParam("offset") Integer offset,
+
+            @QueryParam("includes") Iterable<String> includes,
+            @QueryParam("fields") Iterable<String> fields,
+            @QueryParam("api_key")String apiKey
+    ) throws IOException;
+}

--- a/src/main/java/com/hashnot/etsy/ListingProducts.java
+++ b/src/main/java/com/hashnot/etsy/ListingProducts.java
@@ -1,0 +1,29 @@
+package com.hashnot.etsy;
+
+import com.hashnot.etsy.dto.ListingProduct;
+import com.hashnot.etsy.dto.dict.DictionaryResponse;
+
+import javax.ws.rs.*;
+import java.io.IOException;
+
+/**
+ * @author rougeSE
+ */
+@Path("v2/listings")
+public interface ListingProducts {
+
+    @GET
+    @Path("{listing_id}/products/{product_id}")
+    @Produces("application/json")
+    DictionaryResponse<ListingProduct> getProduct(
+            @PathParam("listing_id") int listingId,
+            @PathParam("product_id") int productId,
+
+            @QueryParam("limit") Integer limit,
+            @QueryParam("offset") Integer offset,
+
+            @QueryParam("includes") Iterable<String> includes,
+            @QueryParam("fields") Iterable<String> fields,
+            @QueryParam("api_key")String apiKey
+    ) throws IOException;
+}

--- a/src/main/java/com/hashnot/etsy/dto/ListingInventory.java
+++ b/src/main/java/com/hashnot/etsy/dto/ListingInventory.java
@@ -1,0 +1,96 @@
+package com.hashnot.etsy.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ListingInventory extends EtsyObject 
+{
+	@JsonProperty
+    private List<ListingProduct> products;
+	
+	@JsonProperty("price_on_property")
+    private List<Integer> priceOnProperty;
+	
+	@JsonProperty("quantity_on_property")
+    private List<Integer> quantityOnProperty;
+	
+	@JsonProperty("sku_on_property")
+    private List<Integer> skuOnProperty;
+	
+	/**
+	 * The products available for this listing. 	
+	 * @return
+	 */
+	public List<ListingProduct> getProducts() {
+		return products;
+	}
+
+	/**
+	 * The products available for this listing. 
+	 * @param products
+	 */
+	public void setProducts(List<ListingProduct> products) {
+		this.products = products;
+	}
+
+	/**
+	 * Which properties control price? 
+	 * @return
+	 */
+	public List<Integer> getPriceOnProperty() {
+		return priceOnProperty;
+	}
+
+	/**
+	 * Which properties control price? 
+	 * @param priceOnProperty
+	 */
+	public void setPriceOnProperty(List<Integer> priceOnProperty) {
+		this.priceOnProperty = priceOnProperty;
+	}
+
+	/**
+	 * Which properties control quantity?
+	 * @return
+	 */
+	public List<Integer> getQuantityOnProperty() {
+		return quantityOnProperty;
+	}
+
+	/**
+	 * Which properties control quantity?
+	 * @param quantityOnProperty
+	 */
+	public void setQuantityOnProperty(List<Integer> quantityOnProperty) {
+		this.quantityOnProperty = quantityOnProperty;
+	}
+
+	/**
+	 * Which properties control SKU? 
+	 * @return
+	 */
+	public List<Integer> getSkuOnProperty() {
+		return skuOnProperty;
+	}
+
+	/**
+	 * Which properties control SKU? 
+	 * @param skuOnProperty
+	 */
+	public void setSkuOnProperty(List<Integer> skuOnProperty) {
+		this.skuOnProperty = skuOnProperty;
+	}
+
+
+	@Override
+    public String toString() {
+        return "Inventory{" +
+                "products=" + products.toString()+
+                ", priceOnProperty=" + String.valueOf(priceOnProperty)+
+                ", quantityOnProperty=" + String.valueOf(quantityOnProperty) +
+                ", skuOnProperty=" + String.valueOf(skuOnProperty) +
+                '}';
+    }
+	
+}

--- a/src/main/java/com/hashnot/etsy/dto/ListingOffering.java
+++ b/src/main/java/com/hashnot/etsy/dto/ListingOffering.java
@@ -1,0 +1,114 @@
+package com.hashnot.etsy.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ListingOffering extends EtsyObject 
+{
+	@JsonProperty("offering_id")
+    private int offeringId;
+	
+	@JsonProperty
+    private Money price;
+	
+	@JsonProperty
+    private int quantity;
+	
+	@JsonProperty("is_enabled")
+    private Boolean isEnabled;
+	
+	@JsonProperty("is_deleted")
+    private Boolean isDeleted;
+
+
+	/**
+	 * The numeric ID of this offering.
+	 * @return
+	 */
+	public int getOfferingId() {
+		return offeringId;
+	}
+
+	/**The numeric ID of this offering.
+	 * 
+	 * @param offeringId
+	 */
+	public void setOfferingId(int offeringId) {
+		this.offeringId = offeringId;
+	}
+
+	/**
+	 * The price of the product 
+	 * @return
+	 */
+	public Money getPrice() {
+		return price;
+	}
+
+	/**
+	 * The price of the product 
+	 * @param price
+	 */
+	public void setPrice(Money price) {
+		this.price = price;
+	}
+
+	/**
+	 * How many of this product are available?
+	 * @return
+	 */
+	public int getQuantity() {
+		return quantity;
+	}
+
+	/**
+	 * How many of this product are available?
+	 * @param quantity
+	 */
+	public void setQuantity(int quantity) {
+		this.quantity = quantity;
+	}
+
+	/**
+	 * Is the offering shown to buyers? 
+	 * @return
+	 */
+	public Boolean isEnabled() {
+		return isEnabled;
+	}
+
+	/**
+	 * Is the offering shown to buyers? 
+	 * @param isEnabled
+	 */
+	public void setEnabled(Boolean isEnabled) {
+		this.isEnabled = isEnabled;
+	}
+
+	/**
+	 * Has the offering been deleted? 
+	 * @return
+	 */
+	public Boolean isDeleted() {
+		return isDeleted;
+	}
+
+	/**
+	 * Has the offering been deleted? 
+	 * @param isDeleted
+	 */
+	public void setDeleted(Boolean isDeleted) {
+		this.isDeleted = isDeleted;
+	}
+	
+	@Override
+    public String toString() {
+        return "Offering{" +
+                "offeringId=" + offeringId+
+                ", price='" + price.toString()+ '\'' +
+                ", quantity=" + quantity +
+                ", isEnabled=" + isEnabled +
+                ", isDeleted='" + isDeleted +
+                '}';
+    }
+	
+}

--- a/src/main/java/com/hashnot/etsy/dto/ListingProduct.java
+++ b/src/main/java/com/hashnot/etsy/dto/ListingProduct.java
@@ -1,0 +1,123 @@
+package com.hashnot.etsy.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.deser.impl.PropertyValue;
+
+/**
+ * A class representing a single product in Etsy.
+ */
+public class ListingProduct extends EtsyObject {
+
+	@JsonProperty("product_id")
+    private int productId;
+	
+	@JsonProperty("property_values")
+	private List<PropertyValue> propertyValues;
+	
+	@JsonProperty
+	private String sku;
+	
+	@JsonProperty
+	private List<ListingOffering> offerings;
+	
+	@JsonProperty("is_deleted")
+	private Boolean isDeleted;
+
+	/**
+	 * The numeric ID of this product. 
+	 * @return
+	 */
+	public int getProductId() {
+		return productId;
+	}
+
+	/**
+	 * The numeric ID of this product. 
+	 * @param productId
+	 */
+	public void setProductId(int productId) {
+		this.productId = productId;
+	}
+
+	/**
+	 * A list of 0-2 properties associated with 
+	 * this product and their values. 
+	 * @return
+	 */
+	public List<PropertyValue> getPropertyValues() {
+		return propertyValues;
+	}
+
+	/**
+	 * A list of 0-2 properties associated with 
+	 * this product and their values. 
+	 * @param propertyValues
+	 */
+	public void setPropertyValues(List<PropertyValue> propertyValues) {
+		this.propertyValues = propertyValues;
+	}
+
+	/**
+	 * The product identifier (if set). 
+	 * @return
+	 */
+	public String getSku() {
+		return sku;
+	}
+
+	/**
+	 * The product identifier (if set). 
+	 * @param sku
+	 */
+	public void setSku(String sku) {
+		this.sku = sku;
+	}
+
+	/**
+	 * A JSON list of active offerings 
+	 * for this product. 
+	 * @return
+	 */
+	public List<ListingOffering> getOfferings() {
+		return offerings;
+	}
+
+	/**
+	 * A JSON list of active offerings 
+	 * for this product. 
+	 * @param offerings
+	 */
+	public void setOfferings(List<ListingOffering> offerings) {
+		this.offerings = offerings;
+	}
+
+	/**
+	 * Has the product been deleted?
+	 * @return
+	 */
+	public Boolean isDeleted() {
+		return isDeleted;
+	}
+
+	/**
+	 * Has the product been deleted?
+	 * @param isDeleted
+	 */
+	public void setDeleted(Boolean isDeleted) {
+		this.isDeleted = isDeleted;
+	}
+	
+	@Override
+    public String toString() {
+        return "Product{" +
+                "productId=" + productId+
+                ", propertyValues='" + propertyValues.toString()+ '\'' +
+                ", sku=" + sku +
+                ", offerings=" + offerings.toString() +
+                ", isDeleted='" + isDeleted +
+                '}';
+    }
+	
+}

--- a/src/main/java/com/hashnot/etsy/dto/dict/DictionaryResponse.java
+++ b/src/main/java/com/hashnot/etsy/dto/dict/DictionaryResponse.java
@@ -3,8 +3,6 @@ package com.hashnot.etsy.dto.dict;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hashnot.etsy.dto.Pagination;
 
-import java.util.List;
-
 /**
  * @author Rafał Krupiński
  */
@@ -20,4 +18,8 @@ public class DictionaryResponse<T> {
 
     @JsonProperty("pagination")
     private Pagination pagination;
+	
+	public T getResult() {
+		return results;
+	}
 }


### PR DESCRIPTION
The Response object has a getTypes that returns a List<T>, but some
of the responses from Etsy are not a list of things. Using the Response
type was causing a JSON parsing error.

Looked like the DictionaryReponse might be the correct type for handling
a single response as it had all the other fields of a Response (count,
type, pagination), so added a getType that just returns a T.